### PR TITLE
User menu draft re: #16, PR #21 and #31

### DIFF
--- a/parts/nav-bftop.php
+++ b/parts/nav-bftop.php
@@ -10,9 +10,27 @@
             <div class="cell medium-auto" style="margin: 0 auto;">
 				<?php get_template_part( 'parts/nav', 'bfsubmenu' ); ?>
             </div>
-        </div>
-        <div class="cell" style="width: 54px; height: 54px;"> 
-          User
+		</div>
+		<!-- The following uses Foundation's dropdown menu component -->
+		<div class="cell" style="width: 70px; height: 54px; z-index: 100;">
+		<!-- The width is bigger than the height to accommodate the dropdown triangle -->
+        	<ul class="dropdown menu" data-dropdown-menu>
+				  <li><a href="<?php bp_loggedin_user_link(); ?>"><?php bp_loggedin_user_avatar( 'type=full' ); ?></a>
+				  <!-- check buddypress.wp-a2z.org for details on these functions. The parameters for ..._avatar are under bp_core_fetch_avatar() -->
+					<ul class="menu">
+						<li><a href="/wp-admin/">Admin Dashboard</a></li>
+						<li><a href="/wp-login.php?action=logout">Logout</a></li>
+						<!-- logout doesn't fully work yet -->
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/profile/edit/">Edit My Profile</a></li>
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/profile/change-avatar/">Change Avatar</a></li>
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/messages/">Messages</a></li>
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/compose/">Compose Message</a></li>
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/settings/">Email/Password Settings</a></li>
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/settings/notifications/">Notification Settings</a></li>
+						<li><a href="/members/<?php bp_loggedin_user_username(); ?>/settings/profile/">Profile Settings</a></li>
+					</ul>
+				</li>
+			</ul>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This is a next step for the User menu first described in #16, then PR #21 and now #31.

It uses Foundation’s dropdown menu component. Please look at comments in the code for additional details.

I _am_ expecting to back off from coding as we move along but this was a great help in my learning process with using Foundation. I would summarize those learnings this way:

- Foundation has [fabulous documentation](https://foundation.zurb.com/sites/docs/) - well worth browsing to get acquainted and then returning to when there is a specific need/use.
- Foundation works fine in our site.
- An easy way to test various Foundation components in your local dev instance is to use footer.php and insert the demo code just below the end of the php-based comment and before the other html.