### PR TITLE
Simplification of the single topic page

### DIFF
--- a/bbpress/content-single-topic.php
+++ b/bbpress/content-single-topic.php
@@ -23,7 +23,7 @@
 
 		<?php bbp_topic_tag_list(); ?>
 
-		<?php bbp_single_topic_description(); ?>
+
 
 		<?php if ( bbp_show_lead_topic() ) : ?>
 

--- a/bbpress/loop-replies.php
+++ b/bbpress/loop-replies.php
@@ -13,29 +13,6 @@
 
 <ul id="topic-<?php bbp_topic_id(); ?>-replies" class="forums bbp-replies">
 
-	<li class="bbp-header">
-
-		<div class="bbp-reply-author"><?php  _e( 'Author',  'bbpress' ); ?></div><!-- .bbp-reply-author -->
-
-		<div class="bbp-reply-content">
-
-			<?php if ( !bbp_show_lead_topic() ) : ?>
-
-				<?php _e( 'Posts', 'bbpress' ); ?>
-
-				<?php bbp_topic_subscription_link(); ?>
-
-				<?php bbp_user_favorites_link(); ?>
-
-			<?php else : ?>
-
-				<?php _e( 'Replies', 'bbpress' ); ?>
-
-			<?php endif; ?>
-
-		</div><!-- .bbp-reply-content -->
-
-	</li><!-- .bbp-header -->
 
 	<li class="bbp-body">
 
@@ -55,25 +32,6 @@
 
 	</li><!-- .bbp-body -->
 
-	<li class="bbp-footer">
-
-		<div class="bbp-reply-author"><?php  _e( 'Author',  'bbpress' ); ?></div>
-
-		<div class="bbp-reply-content">
-
-			<?php if ( !bbp_show_lead_topic() ) : ?>
-
-				<?php _e( 'Posts', 'bbpress' ); ?>
-
-			<?php else : ?>
-
-				<?php _e( 'Replies', 'bbpress' ); ?>
-
-			<?php endif; ?>
-
-		</div><!-- .bbp-reply-content -->
-
-	</li><!-- .bbp-footer -->
 
 </ul><!-- #topic-<?php bbp_topic_id(); ?>-replies -->
 

--- a/bbpress/loop-single-reply.php
+++ b/bbpress/loop-single-reply.php
@@ -9,32 +9,6 @@
 
 ?>
 
-<div id="post-<?php bbp_reply_id(); ?>" class="bbp-reply-header">
-
-	<div class="bbp-meta">
-
-		<span class="bbp-reply-post-date"><?php bbp_reply_post_date(); ?></span>
-
-		<?php if ( bbp_is_single_user_replies() ) : ?>
-
-			<span class="bbp-header">
-				<?php _e( 'in reply to: ', 'bbpress' ); ?>
-				<a class="bbp-topic-permalink" href="<?php bbp_topic_permalink( bbp_get_reply_topic_id() ); ?>"><?php bbp_topic_title( bbp_get_reply_topic_id() ); ?></a>
-			</span>
-
-		<?php endif; ?>
-
-		<a href="<?php bbp_reply_url(); ?>" class="bbp-reply-permalink">#<?php bbp_reply_id(); ?></a>
-
-		<?php do_action( 'bbp_theme_before_reply_admin_links' ); ?>
-
-		<?php bbp_reply_admin_links(); ?>
-
-		<?php do_action( 'bbp_theme_after_reply_admin_links' ); ?>
-
-	</div><!-- .bbp-meta -->
-
-</div><!-- #post-<?php bbp_reply_id(); ?> -->
 
 <div <?php bbp_reply_class(); ?>>
 
@@ -42,18 +16,8 @@
 
 		<?php do_action( 'bbp_theme_before_reply_author_details' ); ?>
 
-		<?php bbp_reply_author_link( array( 'sep' => '<br />', 'show_role' => true ) ); ?>
-
-		<?php if ( bbp_is_user_keymaster() ) : ?>
-
-			<?php do_action( 'bbp_theme_before_reply_author_admin_details' ); ?>
-
-			<div class="bbp-reply-ip"><?php bbp_author_ip( bbp_get_reply_id() ); ?></div>
-
-			<?php do_action( 'bbp_theme_after_reply_author_admin_details' ); ?>
-
-		<?php endif; ?>
-
+		<?php bbp_reply_author_link( array( 'sep' => '<br />', 'show_role' => false ) ); ?>
+		<span class="bbp-reply-post-date"><?php bbp_reply_post_date(); ?></span>
 		<?php do_action( 'bbp_theme_after_reply_author_details' ); ?>
 
 	</div><!-- .bbp-reply-author -->
@@ -65,6 +29,30 @@
 		<?php bbp_reply_content(); ?>
 
 		<?php do_action( 'bbp_theme_after_reply_content' ); ?>
+
+		<div class="bbp-meta">
+
+		<?php if ( bbp_is_single_user_replies() ) : ?>
+
+			<span class="bbp-header">
+				<?php _e( 'in reply to: ', 'bbpress' ); ?>
+				<a class="bbp-topic-permalink" href="<?php bbp_topic_permalink( bbp_get_reply_topic_id() ); ?>"><?php bbp_topic_title( bbp_get_reply_topic_id() ); ?></a>
+			</span>
+
+		<?php endif; ?>
+
+		<!-- <a href="<?php bbp_reply_url(); ?>" class="bbp-reply-permalink">#<?php bbp_reply_id(); ?></a> -->
+
+		<?php do_action( 'bbp_theme_before_reply_admin_links' ); ?>
+
+		<?php bbp_reply_admin_links(); ?>
+
+		<?php do_action( 'bbp_theme_after_reply_admin_links' ); ?>
+
+		</div><!-- .bbp-meta -->
+
+		
+
 
 	</div><!-- .bbp-reply-content -->
 

--- a/bbpress/pagination-replies.php
+++ b/bbpress/pagination-replies.php
@@ -12,11 +12,6 @@
 <?php do_action( 'bbp_template_before_pagination_loop' ); ?>
 
 <div class="bbp-pagination">
-	<div class="bbp-pagination-count">
-
-		<?php bbp_topic_pagination_count(); ?>
-
-	</div>
 
 	<div class="bbp-pagination-links">
 

--- a/buddypress/groups/single/home.php
+++ b/buddypress/groups/single/home.php
@@ -13,19 +13,9 @@ if ( bp_has_groups() ) :
 
 		<?php bp_nouveau_group_hook( 'before', 'home_content' ); ?>
 
-		<div id="item-header" role="complementary" data-bp-item-id="<?php bp_group_id(); ?>" data-bp-item-component="groups" class="groups-header single-headers">
-
-			<?php bp_nouveau_group_header_template_part(); ?>
-
-		</div><!-- #item-header -->
 
 		<div class="bp-wrap">
 
-			<?php if ( ! bp_nouveau_is_object_nav_in_sidebar() ) : ?>
-
-				<?php bp_get_template_part( 'groups/single/parts/item-nav' ); ?>
-
-			<?php endif; ?>
 
 			<div id="item-body" class="item-body">
 


### PR DESCRIPTION
I've been wanting to do this for a couple of years! In the last few days I've been sorting out how the bp and bbp template systems work. With that knowledge, I've modified the appropriate templates to significantly reduce the topic-header content. Also moved some elements around in the layout of individual posts.

I made NO css changes. There will still be a lot of styling to do. I see this PR queuing up a good backlog of css work.