### PR TITLE
Match font size of page title to thread title on forum topic pages

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -455,5 +455,9 @@ PLUGIN STYLES
 }
 
 .forum.single-item .page-title {
-	font-size: 1.9375rem;
+	font-size: 1rem;
+}
+
+.item-body h3 {
+	font-size: 3rem;
 }

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -458,6 +458,6 @@ PLUGIN STYLES
 	font-size: 1rem;
 }
 
-.item-body h3 {
+#item-body h3 {
 	font-size: 3rem;
 }

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -460,4 +460,5 @@ PLUGIN STYLES
 
 #item-body h3 {
 	font-size: 3rem;
+    margin: 0;
 }

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -460,5 +460,5 @@ PLUGIN STYLES
 
 #item-body h3 {
 	font-size: 3rem;
-    margin: 0;
+	margin: 0;
 }

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -453,3 +453,7 @@ PLUGIN STYLES
 			grid-template-areas: 'Logo TopMenu User' 'Logo SubMenu User';
 	}
 }
+
+.forum.single-item .page-title {
+	font-size: 1.9375rem;
+}


### PR DESCRIPTION
On forum topic pages, changed the font size of page title to match font size of the thread title by styling .forum.single-item .page-title.

Fixed #50 by styling .forum.single-item .page-title so the font size of the page title matches the thread title.