### PR TITLE
Added More... menu item with second copy of submenu items

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -446,6 +446,11 @@ PLUGIN STYLES
 	margin: 0 auto;
 }
 
+.header-submenu .bp-navs {
+	z-index:100;
+	overflow: visible	
+}
+
 @media (min-width:768px) {
 	.header-grid {
 			grid-template-columns: 60px 1fr 60px;

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -8,37 +8,36 @@ add_filter('show_admin_bar','__return_false');
 // This is based on https://codex.buddypress.org/developer/navigation-api/
 function bfc_nav_configure() {
 	global $bp;
-    if( bp_is_group() ) {
+	if( bp_is_group() ) {
 		$bp->groups->nav->edit_nav( array( 'name' => __( 'G-Dash', 'buddypress' )), 'home', bp_current_item() );
 
 		// comment those you want to show
 	   $hide_tabs = array(             
-        	'announcements'    => 1,
-        	'invite-anyone'    => 1,
-        	'notifications'    => 1,
-        );
-                   
-        $parent_nav_slug = bp_get_current_group_slug();
-  
+			'announcements'    => 1,
+			'invite-anyone'    => 1,
+			'notifications'    => 1,
+		);
+
+		$parent_nav_slug = bp_get_current_group_slug();
+
 		//Remove the nav items
 		foreach ( array_keys( $hide_tabs ) as $tab ) {
 			bp_core_remove_subnav_item( $parent_nav_slug, $tab, 'groups' );
 		}   
-    } elseif ( bp_is_user() ) {
+	} elseif ( bp_is_user() ) {
 		$hide_tabs = array(             
-        	'invite-anyone'    => 1,
-        	'following'    => 1,
-        	'followers'    => 1,
-        	'forums'   		   => 1,
-        );
-                     
+			'invite-anyone'	=> 1,
+			'following'		=> 1,
+			'followers'		=> 1,
+			'forums'		=> 1,
+		);
 		//Remove the nav items
 		foreach ( array_keys( $hide_tabs ) as $tab ) {
 			bp_core_remove_nav_item( $tab, 'members' );
-		}   
+		}
 
 	}
-}    
+}
 add_action( 'bp_actions', 'bfc_nav_configure' );
 
 

--- a/parts/nav-bfc-submenu.php
+++ b/parts/nav-bfc-submenu.php
@@ -1,8 +1,7 @@
 <?php if ( bfc_nouveau_has_nav() ) : ?>
-<nav class="main-navs no-ajax bp-navs single-screen-navs horizontal users-nav buddypress-wrap" id="object-nav" role="navigation" aria-label="User menu">
-	
-	<ul id="menu-subnav-1" class="medium-horizontal menu dropdown" >
+<nav class="main-navs no-ajax bp-navs single-screen-navs horizontal users-nav buddypress-wrap" id="object-nav" role="navigation" aria-label="User menu"> 	
 
+	<ul id="menu-subnav-1" class="medium-horizontal menu dropdown" >
 		<?php
 		while ( bp_nouveau_nav_items() ) :
 			bp_nouveau_nav_item();
@@ -16,6 +15,23 @@
 
 		<?php endwhile; ?>
 
+		<li id="more" class="<?php bp_nouveau_nav_classes(); ?>">
+		<span class="menu-more" data-toggle="more-dropdown">More ...</span>
+			<div class="dropdown-pane" id="more-dropdown" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="true">
+				<ul>
+					<?php
+					while ( bp_nouveau_nav_items() ) :
+						bp_nouveau_nav_item();
+					?>
+						<li id="<?php bp_nouveau_nav_id(); ?>" class="<?php bp_nouveau_nav_classes(); ?>">
+							<a href="<?php bp_nouveau_nav_link(); ?>" id="<?php bp_nouveau_nav_link_id(); ?>">
+								<?php bp_nouveau_nav_link_text(); ?>
+							</a>
+						</li>
+					<?php endwhile; ?>
+				</ul>
+			</div>
+		</li>
 	</ul>
 </nav>
 <?php endif; 


### PR DESCRIPTION
As a step toward making the submenus responsive #69 , I've added a More... item at the end of the regular submenu. I've attached a Foundation dropdown panel to the More... and filled the panel with a second copy of the submenu.

The selectors in that second copy are currently the same as in the first copy. This should be reviewed to avoid conflicts and allow differentiated targeting of the second copy. Any suggestions on how to setup the selectors for the second copy would be welcome.

At least it works this far. :-)