### PR TITLE
Rounded corners of avatar images

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -743,8 +743,16 @@ body {
 	margin: 0;
 }
 
+div.header-user img.avatar {
+  border-radius: 10px;
+}
+
 #bbpress-forums img.avatar {
-	border-radius: 10px;
+	border-radius: 12px;
+}
+
+#item-header-avatar img.avatar {
+  border-radius: 16px;
 }
 
 #bbpress-forums .bbp-reply-post-date {


### PR DESCRIPTION
Fixed #73 by styling border radius of avatar user images to be a slightly rounded on small user profile image, medium post image, and large profile image (see screenshots).

<img width="106" alt="screen shot 2018-11-08 at 2 26 17 pm" src="https://user-images.githubusercontent.com/7103794/48231732-067ead00-e364-11e8-9d2a-0e7eceb22e4e.png">

Small user image set to 10px border radius

<img width="127" alt="screen shot 2018-11-08 at 2 26 40 pm" src="https://user-images.githubusercontent.com/7103794/48231751-16968c80-e364-11e8-9f5a-cd0aad45c4d1.png">

Medium post image set to 12px border radius

<img width="210" alt="screen shot 2018-11-08 at 2 27 08 pm" src="https://user-images.githubusercontent.com/7103794/48231780-3037d400-e364-11e8-952b-5ee88751f942.png">

Large profile image set to 16px border radius


