### PR TITLE
Attach a dropdown panel (menu) to the logo

### DIFF
--- a/assets/images/menuarrow.svg
+++ b/assets/images/menuarrow.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="12px" height="40px" viewBox="0 0 12 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51.3 (57544) - http://www.bohemiancoding.com/sketch -->
+    <title>Artboard</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <polygon id="Triangle" fill="#CCCCCC" transform="translate(5.000000, 36.000000) scale(1, -1) translate(-5.000000, -36.000000) " points="5 32 10 40 0 40"></polygon>
+    </g>
+</svg>

--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -492,7 +492,7 @@ body {
 /* HEADER */
 .header-grid {
 	display: grid;
-	grid-template-columns: 50px 1fr 50px;
+	grid-template-columns: 52px 1fr 52px;
 	grid-template-rows: 20px 20px;
 	grid-template-areas: 'Logo TopMenu User' 'Logo SubMenu User';
 	margin: 10px 15px;
@@ -502,7 +502,11 @@ body {
 
 .header-logo {
 	grid-area: Logo;
-	margin-right: 10px;
+}
+
+.header-logo img,
+.header-user img {
+	max-width: 40px;
 }
 
 .header-topmenu {
@@ -513,7 +517,6 @@ body {
 .header-user {
 	grid-area: User;
 	z-index: 100;
-	margin-left: 10px;
 }
 
 .header-submenu {
@@ -531,10 +534,16 @@ body {
 
 @media (min-width:768px) {
 	.header-grid {
-		grid-template-columns: 70px 1fr 70px;
+		grid-template-columns: 72px 1fr 72px;
 		grid-template-rows: 30px 30px;
 		grid-template-areas: 'Logo TopMenu User' 'Logo SubMenu User';
 	}
+	.header-logo img,
+	.header-user img {
+		max-width: 60px;
+		vertical-align: bottom;
+	}
+
 }
 
 /* FORUMS */
@@ -993,7 +1002,7 @@ div.header-user img.avatar {
 	}
 	.header-grid {
 		display: grid;
-		grid-template-columns: 44px 1fr 44px;
+		grid-template-columns: 52px 1fr 52px;
 		grid-template-rows: 20px 20px;
 		grid-template-areas: 'Logo TopMenu User' 'Logo SubMenu User';
 		margin: 6px 15px 6px 8px;
@@ -1003,7 +1012,6 @@ div.header-user img.avatar {
 	
 	.header-logo {
 		grid-area: Logo;
-		margin-right: 4px;
 	}
 	
 	.header-topmenu {
@@ -1014,6 +1022,5 @@ div.header-user img.avatar {
 	.header-user {
 		grid-area: User;
 		z-index: 100;
-		margin-left: 4px;
 	}
 }

--- a/parts/nav-bfc-top.php
+++ b/parts/nav-bfc-top.php
@@ -1,7 +1,19 @@
 
 <header class="header-grid">
 	<div class="header-logo">
-		<a href="<?php echo home_url(); ?>"><img src="/wp-content/themes/bfcom/assets/images/logo9b.svg" alt="Logo"/></a>
+		<span data-toggle="logo-dropdown"><img class="logo-img" src="/wp-content/themes/bfcom/assets/images/logo9b.svg" alt="Logo"/><img src="/wp-content/themes/bfcom/assets/images/menuarrow.svg" alt="Menu Arrow"/></span>
+		<div class="dropdown-pane" id="logo-dropdown" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="true">
+		<ul>
+			<li><a href="/">Home</a></li>
+			<li><a href="/about/">About this site</a></li>
+			<li><a href="https://www.context.org">Main CI site</a></li>
+			<li><a href="/about/contact/">Contact</a></li>
+			<li><a href="/about/help/">Help</a></li>
+			<li><a href="/about/terms-rules/">Terms of Service</a></li>
+			<li><a href="/about/privacy-policy/">Privacy</a></li>
+		</ul>
+	</div>
+	
 	</div>
 	<div class="header-topmenu">
     <?php bfc_top_nav(); ?> <!-- this replaces the call to joints_top_nav(); -->
@@ -10,7 +22,7 @@
 		<a href="/wp-login.php?action=login">Log in</a>
 	<?php else : ?>
 		<div class="header-user">
-			<span data-toggle="user-dropdown"><?php bp_loggedin_user_avatar( 'type=full' ); ?></span>
+			<span data-toggle="user-dropdown"><img src="/wp-content/themes/bfcom/assets/images/menuarrow.svg" alt="Menu Arrow"/><?php bp_loggedin_user_avatar( 'type=full' ); ?></span>
 			<div class="dropdown-pane" id="user-dropdown" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="true">
 				<ul>
 					<li><a href="/wp-admin/">Admin Dashboard</a></li>


### PR DESCRIPTION
This is discussed in issue #78. I have added an arrow image as an indicator of a dropdown next to both the logo and the user image. This arrow is positioned to the right of the logo and left of the user image so that the two arrows are "inside" their respective main images.

The links in the logo dropdown are meant to be indicative but by no means final.