### PR TITLE
Add dropdown panes to avatars in member listings

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -1024,6 +1024,8 @@ div.header-user img.avatar {
 		z-index: 100;
 	}
 }
+
+/* member directory */
 .directory.members ul#members-list {
 	display: grid;
 	grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));

--- a/buddypress/groups/single/members-loop.php
+++ b/buddypress/groups/single/members-loop.php
@@ -25,10 +25,15 @@
 				<div class="list-wrap">
 
 					<div class="item-avatar">
-						<?php bp_group_member_avatar(); ?><br>
+						<span data-toggle="gmem-dropdown-<?php echo esc_attr( bp_get_group_member_id() ); ?>"><?php bp_group_member_avatar(); ?></span><br>
 						<span class="list-title member-name"><?php bp_member_name(); ?></span>
+						<div class="dropdown-pane" id="gmem-dropdown-<?php echo esc_attr( bp_get_group_member_id() ); ?>" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="true">
+							<a href="/members/<?php echo bp_core_get_username(bp_loggedin_user_id()); ?>/messages/compose/?r=<?php echo bp_core_get_username(bp_get_group_member_id()); ?>">Send a message</a><br>
+							<?php bp_follow_add_follow_button('leader_id=' . bp_get_group_member_id()); ?> <br>
+							<a href="/members/<?php echo bp_core_get_username(bp_get_group_member_id()); ?>">Visit profile</a><br>
+							Plus info from profile
+						</div>
 					</div>
-
 					<div class="item-intro">
 						<?php
 						$args = array('field' => 8, 'user_id' => bp_get_group_member_id());
@@ -49,6 +54,10 @@
 	<?php bp_nouveau_pagination( 'bottom' ); ?>
 
 	<?php bp_nouveau_group_hook( 'after', 'members_content' ); ?>
+
+	<script>
+		jQuery(document).foundation();
+	</script>
 
 <?php else :
 

--- a/buddypress/members/members-loop.php
+++ b/buddypress/members/members-loop.php
@@ -22,12 +22,16 @@ bp_nouveau_before_loop(); ?>
 
 		<li <?php bp_member_class( array( 'item-entry' ) ); ?> data-bp-item-id="<?php bp_member_user_id(); ?>" data-bp-item-component="members">
 			<div class="list-wrap">
-
+			
 				<div class="item-avatar">
-					<a href="<?php bp_member_permalink(); ?>"><?php bp_member_avatar( bp_nouveau_avatar_args() ); ?></a><br>
-					<span class="list-title member-name">
-						<a href="<?php bp_member_permalink(); ?>"><?php bp_member_name(); ?></a>
-					</span>
+					<span data-toggle="member-dropdown-<?php bp_member_user_id() ; ?>"><?php bp_member_avatar( bp_nouveau_avatar_args() ); ?></span><br>
+					<span class="list-title member-name"><?php bp_member_name(); ?></span>
+					<div class="dropdown-pane" id="member-dropdown-<?php bp_member_user_id(); ?>" data-dropdown data-hover="true" data-hover-pane="true" data-auto-focus="true">
+							<a href="/members/<?php echo bp_core_get_username(bp_loggedin_user_id()); ?>/messages/compose/?r=<?php echo bp_core_get_username(bp_get_member_user_id()); ?>">Send a message</a><br>
+							<?php bp_follow_add_follow_button('leader_id=' . bp_get_member_user_id()); ?> <br>
+							<a href="/members/<?php echo bp_core_get_username(bp_get_member_user_id()); ?>">Visit profile</a><br>
+							Plus info from profile
+					</div>
 				</div>
 			</div>
 		</li>
@@ -47,3 +51,7 @@ endif;
 ?>
 
 <?php bp_nouveau_after_loop(); ?>
+
+<script>
+		jQuery(document).foundation();
+	</script>

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -378,3 +378,28 @@ function bfc_widgets_init() {
 
 }
 add_action( 'widgets_init', 'bfc_widgets_init' );
+
+// From https://gist.github.com/rohmann/6151699 
+add_action('load-users.php',function() {
+
+	if(isset($_GET['action']) && isset($_GET['bp_gid']) && isset($_GET['users'])) {
+		$group_id = $_GET['bp_gid'];
+		$users = $_GET['users'];
+		foreach ($users as $user_id) {
+			groups_join_group( $group_id, $user_id );
+		}
+	}
+		//Add some Javascript to handle the form submission
+		add_action('admin_footer',function(){ ?>
+		<script>
+			jQuery("select[name='action']").append(jQuery('<option value="groupadd">Add to BP Group</option>'));
+			jQuery("#doaction").click(function(e){
+				if(jQuery("select[name='action'] :selected").val()=="groupadd") { e.preventDefault();
+					gid=prompt("Please enter a BuddyPres Group ID","1");
+					jQuery(".wrap form").append('<input type="hidden" name="bp_gid" value="'+gid+'" />').submit();
+				}
+			});
+		</script>
+		<?php
+		});
+	});


### PR DESCRIPTION
This is at the proof of concept stage ... and it works! When you hover over the avatar in either the main People directory or a group member listing, you get a dropdown that can be filled with whatever useful links and info we like. Here's a screenshot:

![screen shot 2019-01-03 at 9 16 02 pm](https://user-images.githubusercontent.com/615052/50674644-13eb9880-0f9d-11e9-9308-62748657e0c5.png)

This has no styling done whatsoever (e.g. the overlap). Nevertheless, the links are all functional to illustrate what can be done.