### PR TITLE
Created footer menu template method similar to header menu template

### DIFF
--- a/assets/styles/style.css
+++ b/assets/styles/style.css
@@ -743,7 +743,7 @@ div.header-user img.avatar {
 	}
 
 	.header-grid,
-	.forum.single-item .page-title {
+	.forum.single-item .page-title, .menu-item-footer {
 		font-size: calc(14px + 2*((100vw - 320px)/320));
 	}
 }
@@ -841,7 +841,7 @@ div.header-user img.avatar {
 }
 /* Hightlights active/selected menu item.  */
 .menu .active > a,
-.bp-navs .selected a, 
+.bp-navs .selected a,
 .bp-navs span.selected {
 	background: none;
 	color: #1e1e1e;
@@ -969,16 +969,16 @@ div.header-user img.avatar {
 		margin-top: -5px;
 		padding: 0px 6px 2px;
 	}
-	
+
 	.menu a img {
 		padding: 2px 2px 0px;
 		height: 22px;
 	}
-	
+
 	.bp-navs .selected a {
 		font-size: inherit;
 	}
-	
+
 	.header-submenu {
 		padding-top: 2px;
 	}
@@ -1017,16 +1017,16 @@ div.header-user img.avatar {
 		border-bottom: 1px solid #ccc;
 		padding-bottom: 6px;
 	}
-	
+
 	.header-logo {
 		grid-area: Logo;
 	}
-	
+
 	.header-topmenu {
 		grid-area: TopMenu;
 		margin: 0 auto;
 	}
-	
+
 	.header-user {
 		grid-area: User;
 		z-index: 100;
@@ -1075,19 +1075,19 @@ div.header-user img.avatar {
 		grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
 		grid-gap: 6px;
 	}
-	
+
 	.directory.members #members-list.bp-list .item-avatar {
 		font-size: 12px;
 		line-height: 13px;
 	}
-	
+
 	.directory.members #members-list .item-avatar img.avatar {
 		width: 80px;
 		height: 80px;
 		margin: 8px 0 6px;
 		border-radius: 3px;
 	}
-	
+
 }
 
 #members-group-list .item-intro {

--- a/footer.php
+++ b/footer.php
@@ -7,31 +7,31 @@
  * For more info: https://developer.wordpress.org/themes/basics/template-files/#template-partials
  */
  ?>
-					
+
 				<footer class="footer" role="contentinfo">
-					
+
 					<div class="inner-footer grid-x grid-margin-x grid-padding-x">
-						
+
 						<div class="small-12 medium-12 large-12 cell">
 							<nav role="navigation">
-								<?php joints_footer_links(); ?>
+                				<?php bfc_bottom_nav(); // replaces joints_footer_links(); ?>
 							</nav>
 						</div>
-						
+
 						<div class="small-12 medium-12 large-12 cell">
 							<p class="source-org copyright">&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?>.</p>
 						</div>
-					
+
 					</div> <!-- end #inner-footer -->
-				
+
 				</footer> <!-- end .footer -->
-			
+
 			</div>  <!-- end .off-canvas-content -->
-					
+
 		</div> <!-- end .off-canvas-wrapper -->
-		
+
 		<?php wp_footer(); ?>
-		
+
 	</body>
-	
+
 </html> <!-- end page -->

--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -246,6 +246,88 @@ function bfc_top_nav_is_active($topmenuparent) {
 	}
 }
 
+// footer navitation menu builder
+function bfc_bottom_nav_menu_builder() {
+	$footeritemarray = array (
+		array (
+			'id' => 'menu-item-about', // menu item id 106
+			'classes' => 'menu-item-106', // any unique classes for menu item
+			'page_name' => 'about', // page name to highlight
+			'link_url' => '/about/', // page, use relative urls
+			'text' => 'About' // menu item text
+		),
+		array (
+			'id' => 'menu-item-contact',
+			'classes' => 'menu-item-162',
+			'page_name' => 'contact',
+			'link_url' => '/about-2/contact/',
+			'text' => 'Contact'
+		),
+		array (
+			'id' => 'menu-item-help',
+			'classes' => 'menu-item-161',
+			'page_name' => 'help',
+			'link_url' => '/about-2/help/',
+			'text' => 'Help'
+		),
+		array (
+			'id' => 'menu-item-terms',
+			'classes' => 'menu-item-160',
+			'page_name' => 'terms-rules',
+			'link_url' => '/about-2/terms-rules/',
+			'text' => 'Terms'
+		),
+		array (
+			'id' => 'menu-item-privacy',
+			'classes' => 'menu-item-159',
+			'page_name' => 'privacy-policy',
+			'link_url' => '/about-2/privacy-policy/',
+			'text' => 'Privacy'
+		),
+		array (
+			'id' => 'menu-item-top',
+			'classes' => 'menu-item-168',
+			'page_name' => '',
+			'link_url' => '#top',
+			'text' => 'Top'
+		)
+	);
+	return $footeritemarray;
+}
+
+function bfc_bottom_nav() {
+	// Build collection for this template method
+	$footermenuitemarray = bfc_bottom_nav_menu_builder();
+
+	// set $bottomnav to its initial value
+	$bottomnav = '<ul id="menu-bfcom-footer-menu" class="menu">'; //start with the opening ul and its selectors
+
+	$active_item_found = false;
+	// loop through each menu item in the collection to build topnav html
+	foreach ($footermenuitemarray as $menuitem) {
+		$thismenuitem =  '<li ';
+		$thismenuitem .= 'id="';
+		$thismenuitem .= $menuitem['id'];
+		$thismenuitem .= '" class="menu-item-footer menu-item-type-post_type menu-item-object-page';
+		$thismenuitem .= $menuitem['classes'];
+
+		if (($menuitem['page_name'] != '') && (is_page($menuitem['page_name']))) {
+			// $thismenuitem .= ' active';
+			$active_item_found = true;
+		}
+		$thismenuitem .= '" role="menuitem"><a href="';
+		$thismenuitem .= $menuitem['link_url'];
+		$thismenuitem .= '">';
+		$thismenuitem .= $menuitem['text'];
+		$thismenuitem .= '</a></li>';
+
+		$bottomnav .= $thismenuitem;
+	}
+	$bottomnav .= '</ul>';
+
+	echo $bottomnav;
+}
+
 /* Update post actions menu by removing Spam item */
 function bfc_change_topic_admin_links ($r) {
 	$r['links'] = apply_filters( 'bfc_topic_admin_links', array(
@@ -381,7 +463,7 @@ function bfc_widgets_init() {
 }
 add_action( 'widgets_init', 'bfc_widgets_init' );
 
-// From https://gist.github.com/rohmann/6151699 
+// From https://gist.github.com/rohmann/6151699
 add_action('load-users.php',function() {
 
 	if(isset($_GET['action']) && isset($_GET['bp_gid']) && isset($_GET['users'])) {


### PR DESCRIPTION
…te method

Fixed #102 except for highlighting the active menu item

Style.css
Smooth font resizing of footer menu text
Added .menu-item-footer to font-size calc on line 746 to allow smooth font scaling on resizing.

footer.php
Added call to our custom function bfc_bottom_nav()
Fixed #102: Replaced call to joints_footer_links() on line 17 with a call to bfc_bottom_nav().

bfc_functions.php
Bottom navigation menu template
Fixed #102: Added bfc_bottom_nav_menu_builder() and bfc_bottom_nav_menu() to handle footer menu similarly to how we handle to top navigation menu. This vversion doesn't highlight the active menu item since this causes the menu item to disappear when the viewport becomes narrow.