### PR TITLE
Restructure Groups directory with My Groups and Other Groups

### DIFF
--- a/buddypress/blogs/blogs-loop.php
+++ b/buddypress/blogs/blogs-loop.php
@@ -63,7 +63,7 @@ bp_nouveau_before_loop(); ?>
 
 <?php else : ?>
 
-	bp_nouveau_user_feedback( 'blogs-loop-none' );
+	<?php bp_nouveau_user_feedback( ‘blogs-loop-none’ ); ?>
 
 <?php endif; ?>
 


### PR DESCRIPTION
The default directory page for Groups had two tabs: All Groups and My Groups. I feel this doesn't fit our use. I expect our users will go to this directory most often to find one of their own groups and secondarily to find other groups.

It took me a while to sort out how to do this but it turned out to be relatively easy with the magic of WP-filters.

This PR also includes a bug fix for our templates taken from the recent BuddyPress 4.30 update.