### PR TITLE
Allow expanded tag set in xprofile textarea fields

### DIFF
--- a/functions/bfc-functions.php
+++ b/functions/bfc-functions.php
@@ -527,3 +527,8 @@ add_action('load-users.php',function() {
 	}
 
 	add_filter( 'bp_nouveau_ajax_querystring', 'bfc_ajax_querystring', 10, 7 );
+
+	function bfc_xprofile_allowedtags () {
+		remove_filter( 'bp_get_the_profile_field_edit_value', 'wp_filter_kses', 1 );
+	}
+	add_action( 'wp_loaded', 'bfc_xprofile_allowedtags');


### PR DESCRIPTION
BuddyPress is supposed to allow an expanded HTML tag set in xprofile textarea fields but it appears to have a bug that prevents this. See a bit of discussion about this in [this BP support topic](https://buddypress.org/support/topic/image-not-saving-in-xprofile-textarea-field/#post-305699).

It took a lot of sleuthing  but the workaround in the end is quite simple - just removing a particular filter. This will work fine for us until they fix the bug.

This is a step toward being able to include images and other media in self-intros in member profiles.